### PR TITLE
Codecov report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ notifications:
       - andris16@ru.is
     on_success: never # default: change
     on_failure: always # default: always
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # TicTacToe
 This is a late term assignment for the course Software Development
 Status: [![Build Status](https://travis-ci.org/RU-DDoS/TicTacToe.png)](https://travis-ci.org/RU-DDoS/TicTacToe)
+Coverage: [![codecov](https://codecov.io/gh/RU-DDoS/TicTacToe/branch/master/graph/badge.svg)](https://codecov.io/gh/RU-DDoS/TicTacToe)

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'application'
+apply plugin: 'jacoco'
 
 mainClassName = "is.ru.tictactoe.TicTacToe"
 
@@ -14,3 +15,11 @@ dependencies {
 
 task stage (dependsOn: installDist) {
 }
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled false
+    }
+}
+check.dependsOn jacocoTestReport

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - src/main/java/is/ru/tictactoe/TicTacToe.java


### PR DESCRIPTION
Added code coverage so that we can always access our coverage statistics outside of the build server.
The report can be found [here](https://codecov.io/gh/RU-DDoS/TicTacToe)